### PR TITLE
Allow for absence of <alloca.h> on various Unixes.

### DIFF
--- a/src/c-lib/enc-private.h
+++ b/src/c-lib/enc-private.h
@@ -39,7 +39,10 @@
 #define ssize_t ptrdiff_t
 #define alloca _alloca
 #else
-#include <alloca.h>
+#  if (defined(__GNUC__) && !defined(alloca) && !defined(__NetBSD__)) || defined(__NuttX__) || defined(_AIX) \
+        || (defined(__sun) && defined(__SVR4) /*Solaris*/)
+#    include <alloca.h>
+#  endif
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
Noticed when building on FreeBSD, but the change should work on various other Unixes.