### PR TITLE
dl.c: undefine `gets` in case already a macro

### DIFF
--- a/src/c-lib/dl.c
+++ b/src/c-lib/dl.c
@@ -555,7 +555,7 @@ bool gs1_parseDLuri(gs1_encoder* const ctx, char* const dlData, char* const data
 
 		if (ctx->permitConvenienceAlphas &&
 		    ailen >= 3 && ailen <= 5 &&
-		    !isdigit(*(p+1))) {			// Possible convenience alpha
+		    !isdigit((int)*(p+1))) {		// Possible convenience alpha
 			char alpha[6] = { 0 };
 			memcpy(alpha, p+1, ailen);
 			entry = aiEntryFromAlpha(ctx, alpha);
@@ -607,7 +607,7 @@ bool gs1_parseDLuri(gs1_encoder* const ctx, char* const dlData, char* const data
 		ailen = (size_t)(r-p);
 		if (ctx->permitConvenienceAlphas &&
 		    ailen >= 3 && ailen <= 5 &&
-		    !isdigit(*p)) {
+		    !isdigit((int)*p)) {
 			char alpha[6] = { 0 };
 			memcpy(alpha, ai, ailen);
 			entry = aiEntryFromAlpha(ctx, alpha);

--- a/src/c-lib/gs1encoders-app.c
+++ b/src/c-lib/gs1encoders-app.c
@@ -30,6 +30,9 @@
 static char *inpStr;
 
 // Replacement for the deprecated gets(3) function
+#ifdef gets
+#undef gets
+#endif
 #define gets(i) _gets(i)
 
 static char* _gets(char* const in) {


### PR DESCRIPTION
Also cast `isdigit()` args to int to suppress pedantic char-subscript warning (NetBSD)