### PR TITLE
gs1encoders.h: check _WIN32 and __GNUC__ defined

### DIFF
--- a/src/c-lib/gs1encoders.h
+++ b/src/c-lib/gs1encoders.h
@@ -332,9 +332,9 @@
 // Decorator for public API functions that we export
 #ifdef __EMSCRIPTEN__
 #  define GS1_ENCODERS_API EMSCRIPTEN_KEEPALIVE
-#elif _WIN32
+#elif defined(_WIN32)
 #  define GS1_ENCODERS_API __declspec(dllexport)
-#elif __GNUC__ >= 4
+#elif defined(__GNUC__) && __GNUC__ >= 4
 #  define GS1_ENCODERS_API __attribute__((visibility ("default")))
 #else
 #  define GS1_ENCODERS_API


### PR DESCRIPTION
Suppresses clang warning -Wundef.