### PR TITLE
Fix invalid syntax example for AI (99) - should be in query string

### DIFF
--- a/docs/js-wasm/index.html
+++ b/docs/js-wasm/index.html
@@ -236,7 +236,7 @@ try {
 //
 // gs.dataStr = "^011231231231233310ABC123^99TEST";      // Unbracketed element string, "^" = FNC1
 //
-// gs.dataStr = "https://example.com/01/12312312312333/10/ABC123/99/TEST";   // GS1 Digital Link URI
+// gs.dataStr = "https://example.com/01/12312312312333/10/ABC123?99=TEST";   // GS1 Digital Link URI
 //
 // gs.scanData = "]Q1011231231231233310ABC123\u001D99TEST";   // Barcode scan data, containing a "GS" (ASCII 0x1D) separator
 


### PR DESCRIPTION
Line 239 of https://github.com/gs1/gs1-syntax-engine/blob/main/docs/js-wasm/index.html had incorrect syntax for expressing GS1 AI (99), which should only be expressed in the query string of a GS1 Digital Link URI, not in the URI path information.